### PR TITLE
wget doesn't trust HTTPS on barebone devices

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -66,14 +66,14 @@ QEMU_PACKAGES = gcc make dietlibc-dev
 
 mips/$(QEMU_ROOTBASE):
 	@mkdir -p mips
-	cd mips && wget -c https://people.debian.org/~aurel32/qemu/mips/$(QEMU_ROOTBASE)
+	cd mips && wget -c https://people.debian.org/~aurel32/qemu/mips/$(QEMU_ROOTBASE) --no-check-certificate
 
 mips/$(QEMU_ROOTWORK): mips/$(QEMU_ROOTBASE)
 	qemu-img create -f qcow2 -o backing_file=$(QEMU_ROOTBASE) $@
 
 mips/$(QEMU_KERNEL):
 	@mkdir -p mips
-	cd mips && wget -c https://people.debian.org/~aurel32/qemu/mips/$(QEMU_KERNEL)
+	cd mips && wget -c https://people.debian.org/~aurel32/qemu/mips/$(QEMU_KERNEL) --no-check-certificate
 
 dist.src.tar.gz: Makefile $(FILES) $(HEADERS)
 	tar -c -z -f $@ Makefile $(FILES) $(HEADERS)


### PR DESCRIPTION
I used Debian on UniFi CloudKey  to build a firmware.
Apparently,  wget doesn't trust https://people.debian.org/