### PR TITLE
Changed a path for qemu-img create

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -69,7 +69,7 @@ mips/$(QEMU_ROOTBASE):
 	cd mips && wget -c https://people.debian.org/~aurel32/qemu/mips/$(QEMU_ROOTBASE)
 
 mips/$(QEMU_ROOTWORK): mips/$(QEMU_ROOTBASE)
-	qemu-img create -f qcow2 -o backing_file=$(QEMU_ROOTBASE) $@
+	qemu-img create -f qcow2 -o backing_file=/mips/$(QEMU_ROOTBASE) $@
 
 mips/$(QEMU_KERNEL):
 	@mkdir -p mips


### PR DESCRIPTION
This one works for me on Debian.

Had an error:
```
qemu-img create -f qcow2 -o backing_file=debian_squeeze_mips_standard.qcow2 mips/debian_mips_work.qcow2
qemu-img: mips/debian_mips_work.qcow2: Could not open 'debian_squeeze_mips_standard.qcow2': Could not open 'debian_squeeze_mips_standard.qcow2': No such file or directory: No such file or directory
```
